### PR TITLE
Now we can compare more than two variables

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: sinon
+    versions:
+    - 10.0.0
+    - 9.2.4
+  - dependency-name: mocha
+    versions:
+    - 8.2.1
+    - 8.3.0
+    - 8.3.1
+  - dependency-name: chai
+    versions:
+    - 4.2.0
+    - 4.3.0
+    - 4.3.1
+    - 4.3.3
+  - dependency-name: handlebars
+    versions:
+    - 4.7.6

--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ var template = '{{#is x "same" y}} Are the same {{else}} Not the same {{/is}}';
 Handlebars.compile(template)({ x: 5, y: '5' }); // => " Not the same "
 ```
 
+### More complex comparisons
+
+You can also compare more than two variables by using `are`:
+```
+{{#are x ">" y "and" x "not" z}} ... {{else}} ... {{/are}}
+{{#are x "===" y "or" x ">=" z}} ... {{else}} ... {{/are}}
+```
+
+`are` add two more comparators:
+* `and`
+* `or`
+
 ### Logging
 
 Log one or multiple values to the console:

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,7 +2,8 @@
 <script src="../src/helpers.js"></script>
 
 <script>
-	document.writeln(Handlebars.compile('{{#is foo bar}}Defaults work.{{else}}:({{/is}}')({foo: false, bar: false}));
+	document.writeln(Handlebars.compile('{{#is foo bar}}Is helpers work.{{else}}:({{/is}}')({foo: false, bar: false}));
+	document.writeln(Handlebars.compile('{{#are foo "<" bar "or" foo ">" foo2 "and" foo "<" bar}}Are helpers work.{{else}}:({{/are}}')({foo: 5, bar: 10, foo2: 15}));
 	HandlebarsHelpersRegistry.add('foobar', function(l,r) { return false; });
 	document.writeln(Handlebars.compile('{{#is foo "foobar" bar}}:({{else}}And custom helpers work.{{/is}}')({foo: false, bar: false}));
 </script>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Dan Harper",
   "license": "WTFPL",
   "dependencies": {
-    "handlebars": "1.0.10"
+    "handlebars": "4.7.7"
   },
   "devDependencies": {
     "mocha": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "devDependencies": {
     "mocha": "1.8.2",
     "chai": "1.5.0",
-    "sinon": "1.6.0"
+    "sinon": "11.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "handlebars": "1.0.10"
   },
   "devDependencies": {
-    "mocha": "1.8.2",
+    "mocha": "9.0.0",
     "chai": "1.5.0",
     "sinon": "1.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "mocha": "9.0.0",
-    "chai": "1.5.0",
+    "chai": "4.3.4",
     "sinon": "11.1.1"
   }
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,7 +10,7 @@
 
     var isArray = function(value) {
         return Object.prototype.toString.call(value) === '[object Array]';
-    }
+    };
 
     var ExpressionRegistry = function() {
         this.expressions = [];
@@ -28,7 +28,7 @@
         return this.expressions[operator](left, right);
     };
 
-    var eR = new ExpressionRegistry;
+    var eR = new ExpressionRegistry();
     eR.add('not', function(left, right) {
         return left != right;
     });
@@ -64,12 +64,11 @@
     });
 
     var isHelper = function() {
-        var args = arguments
-        ,   left = args[0]
-        ,   operator = args[1]
-        ,   right = args[2]
-        ,   options = args[3]
-        ;
+        var args = arguments,
+            left = args[0],
+            operator = args[1],
+            right = args[2],
+            options = args[3];
 
         if (args.length == 2) {
             options = args[1];
@@ -91,15 +90,13 @@
     };
 
     var areHelper = function() {
-        var args = arguments
-        , args = arguments
-        , nbArgs = args.length - 1
-        , options = args[args.length - 1]
-        , operators = []
-        , expResult = []
-        ;
+        var args = arguments,
+        nbArgs = args.length - 1,
+        options = args[args.length - 1],
+        operators = [],
+        expResult = [];
 
-        if (nbArgs % 2 == 0 || parseInt(nbArgs % 3) + 1 != parseInt(nbArgs / 3)) {
+        if (nbArgs % 2 === 0 || parseInt(nbArgs % 3) + 1 !== parseInt(nbArgs / 3)) {
             throw new Error('Invalid number of arguments');
         }
 
@@ -111,7 +108,7 @@
             }
         }
 
-        for (var i = 0; i < operators.length; ++i) {
+        for (i = 0; i < operators.length; ++i) {
             var j = i - 1 < 0 ? 0 : i;
             expResult[j + 1] = eR.call(operators[i], expResult[j], expResult[j + 1]);
         }
@@ -120,7 +117,7 @@
             return options.fn(this);
         }
         return options.inverse(this);
-    }
+    };
 
     Handlebars.registerHelper('is', isHelper);
     Handlebars.registerHelper('are', areHelper);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -56,6 +56,12 @@
         }
         return right.indexOf(left) !== -1;
     });
+    eR.add('and', function(left, right) {
+        return left && right;
+    });
+    eR.add('or', function(left, right) {
+        return left || right;
+    });
 
     var isHelper = function() {
         var args = arguments
@@ -84,7 +90,40 @@
         return options.inverse(this);
     };
 
+    var areHelper = function() {
+        var args = arguments
+        , args = arguments
+        , nbArgs = args.length - 1
+        , options = args[args.length - 1]
+        , operators = []
+        , expResult = []
+        ;
+
+        if (nbArgs % 2 == 0 || parseInt(nbArgs % 3) + 1 != parseInt(nbArgs / 3)) {
+            throw new Error('Invalid number of arguments');
+        }
+
+        for (var i = 0; i < nbArgs; i += 3) {
+            expResult.push(eR.call(args[i + 1], args[i], args[i + 2]));
+            if (i + 3 < nbArgs) {
+                operators.push(args[i + 3]);
+                ++i;
+            }
+        }
+
+        for (var i = 0; i < operators.length; ++i) {
+            var j = i - 1 < 0 ? 0 : i;
+            expResult[j + 1] = eR.call(operators[i], expResult[j], expResult[j + 1]);
+        }
+
+        if (expResult[expResult.length - 1]) {
+            return options.fn(this);
+        }
+        return options.inverse(this);
+    }
+
     Handlebars.registerHelper('is', isHelper);
+    Handlebars.registerHelper('are', areHelper);
 
     Handlebars.registerHelper('nl2br', function(text) {
         var nl2br = (text + '').replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1' + '<br>' + '$2');

--- a/test/helpersTest.js
+++ b/test/helpersTest.js
@@ -36,7 +36,7 @@ describe('#is', function () {
 
 	describe('with three arguments', function () {
 		it('throws an error when an operator does not exist', function () {
-			(function () { c('{{#is foo "/" bar}}Y{{/is}}', {foo:'x', bar:'y'}) })
+			(function () { c('{{#is foo "/" bar}}Y{{/is}}', {foo:'x', bar:'y'}); })
 				.should.throw('Unknown operator "/"');
 		});
 
@@ -146,6 +146,35 @@ describe('#is', function () {
 		it('works', function () {
 			HelpersRegistry.add('omg', function() { return true; });
 			c('{{#is foo "omg" bar}}Y{{/is}}', {foo:5,bar:5}).should.equal('Y');
+		});
+	});
+});
+
+describe('#are', function() {
+	describe('With seven arguments', function() {
+		it('throws an error when an operator does not exist', function () {
+			(function () { c('{{#are foo ">=" bar "foobar" bar "!==" 10}}Y{{/are}}', {foo:5, bar:10}); })
+				.should.throw('Unknown operator "foobar"');
+		});
+
+		describe('the and operator', function () {
+			it('passes when left and right are true', function(){
+				c('{{#are foo "not" bar "and" foo "===" "f"}}Y{{/are}}', {foo:'f', bar:'b'}).should.equal('Y');
+			});
+
+			it('fails when left is true and right is false', function(){
+				c('{{#are foo "not" bar "and" foo "!==" 5}}Y{{/are}}', {foo:5, bar:'b'}).should.equal('');
+			});
+		});
+
+		describe('the or operator', function () {
+			it('passes when left is true and right is false', function(){
+				c('{{#are foo "not" bar "or" foo "!==" "a"}}Y{{/are}}', {foo:'f', bar:'b'}).should.equal('Y');
+			});
+
+			it('fails when left is false and right is false', function(){
+				c('{{#are foo "===" bar "or" foo "===" 10}}Y{{/are}}', {foo:5, bar:'b'}).should.equal('');
+			});
 		});
 	});
 });


### PR DESCRIPTION
I added the helper 'are' to compare more than two variables.
I also updated the README and the test file.

It works like that:

```
{{#are x ">" y "and" x "not" z}} ... {{else}} ... {{/are}}
{{#are x "===" y "or" x ">=" z}} ... {{else}} ... {{/are}}
```
